### PR TITLE
[pykaldi] Provide access to the nnet posteriors

### DIFF
--- a/src/nnet3/decodable-online-looped.cc
+++ b/src/nnet3/decodable-online-looped.cc
@@ -232,10 +232,16 @@ void DecodableNnetLoopedOnlineBase::AdvanceChunk() {
 BaseFloat DecodableNnetLoopedOnline::LogLikelihood(int32 subsampled_frame,
                                                     int32 index) {
   EnsureFrameIsComputed(subsampled_frame);
-  // note: we index by 'inde
+  // note: we index by 'index - 1'
   return current_log_post_(
       subsampled_frame - current_log_post_subsampled_offset_,
       index - 1);
+}
+
+// faster direct access to the loglikelihoods by row
+SubVector<BaseFloat> DecodableNnetLoopedOnlineBase::LogLikelihoods(int32 subsampled_frame) {
+  EnsureFrameIsComputed(subsampled_frame);
+  return current_log_post_.Row(subsampled_frame - current_log_post_subsampled_offset_);
 }
 
 

--- a/src/nnet3/decodable-online-looped.cc
+++ b/src/nnet3/decodable-online-looped.cc
@@ -246,6 +246,16 @@ void DecodableNnetLoopedOnlineBase::LogLikelihoods(int32 subsampled_frame,
   loglikes->CopyFromVec(current_log_post_.Row(subsampled_frame - current_log_post_subsampled_offset_));
 }
 
+void DecodableNnetLoopedOnlineBase::LogLikelihoods(int32 subsampled_frame_from,
+						   int32 subsampled_frame_to,
+						   Matrix<BaseFloat> *loglikes) {
+  EnsureFrameIsComputed(subsampled_frame_to - 1); // python range...
+  int num_rows = subsampled_frame_to - subsampled_frame_from;
+  KALDI_ASSERT(num_rows > 0);
+  loglikes->Resize(num_rows, current_log_post_.NumCols());
+  loglikes->CopyFromMat(current_log_post_.RowRange(subsampled_frame_from - current_log_post_subsampled_offset_, num_rows));
+}
+
 
 BaseFloat DecodableAmNnetLoopedOnline::LogLikelihood(int32 subsampled_frame,
                                                     int32 index) {

--- a/src/nnet3/decodable-online-looped.cc
+++ b/src/nnet3/decodable-online-looped.cc
@@ -246,14 +246,13 @@ void DecodableNnetLoopedOnlineBase::LogLikelihoods(int32 subsampled_frame,
   loglikes->CopyFromVec(current_log_post_.Row(subsampled_frame - current_log_post_subsampled_offset_));
 }
 
-void DecodableNnetLoopedOnlineBase::LogLikelihoods(int32 subsampled_frame_from,
-						   int32 subsampled_frame_to,
+void DecodableNnetLoopedOnlineBase::LogLikelihoods(int32 subsampled_frame,
+						   int32 num_frames,
 						   Matrix<BaseFloat> *loglikes) {
-  EnsureFrameIsComputed(subsampled_frame_to - 1); // python range...
-  int num_rows = subsampled_frame_to - subsampled_frame_from;
-  KALDI_ASSERT(num_rows > 0);
-  loglikes->Resize(num_rows, current_log_post_.NumCols());
-  loglikes->CopyFromMat(current_log_post_.RowRange(subsampled_frame_from - current_log_post_subsampled_offset_, num_rows));
+  KALDI_ASSERT(num_frames > 0);
+  EnsureFrameIsComputed(subsampled_frame + num_frames - 1);
+  loglikes->Resize(num_frames, current_log_post_.NumCols());
+  loglikes->CopyFromMat(current_log_post_.RowRange(subsampled_frame - current_log_post_subsampled_offset_, num_frames));
 }
 
 

--- a/src/nnet3/decodable-online-looped.cc
+++ b/src/nnet3/decodable-online-looped.cc
@@ -239,9 +239,11 @@ BaseFloat DecodableNnetLoopedOnline::LogLikelihood(int32 subsampled_frame,
 }
 
 // faster direct access to the loglikelihoods by row
-SubVector<BaseFloat> DecodableNnetLoopedOnlineBase::LogLikelihoods(int32 subsampled_frame) {
+void DecodableNnetLoopedOnlineBase::LogLikelihoods(int32 subsampled_frame,
+						     Vector<BaseFloat> *loglikes) {
   EnsureFrameIsComputed(subsampled_frame);
-  return current_log_post_.Row(subsampled_frame - current_log_post_subsampled_offset_);
+  loglikes->Resize(current_log_post_.NumCols());
+  loglikes->CopyFromVec(current_log_post_.Row(subsampled_frame - current_log_post_subsampled_offset_));
 }
 
 

--- a/src/nnet3/decodable-online-looped.h
+++ b/src/nnet3/decodable-online-looped.h
@@ -82,6 +82,7 @@ class DecodableNnetLoopedOnlineBase: public DecodableInterface {
   }
   // Supply access to the loglikelihoods by row, for efficiency with pykaldi
   void LogLikelihoods(int32 subsampled_frame, Vector<BaseFloat> *loglikes);
+  void LogLikelihoods(int32 subsampled_frame_from, int32 subsampled_frame_to, Matrix<BaseFloat> *loglikes);
 
 
  protected:

--- a/src/nnet3/decodable-online-looped.h
+++ b/src/nnet3/decodable-online-looped.h
@@ -81,7 +81,7 @@ class DecodableNnetLoopedOnlineBase: public DecodableInterface {
     return info_.opts.frame_subsampling_factor;
   }
   // Supply access to the loglikelihoods by row, for efficiency with pykaldi
-  SubVector<BaseFloat> LogLikelihoods(int32 subsampled_frame);
+  void LogLikelihoods(int32 subsampled_frame, Vector<BaseFloat> *loglikes);
 
 
  protected:

--- a/src/nnet3/decodable-online-looped.h
+++ b/src/nnet3/decodable-online-looped.h
@@ -82,7 +82,7 @@ class DecodableNnetLoopedOnlineBase: public DecodableInterface {
   }
   // Supply access to the loglikelihoods by row, for efficiency with pykaldi
   void LogLikelihoods(int32 subsampled_frame, Vector<BaseFloat> *loglikes);
-  void LogLikelihoods(int32 subsampled_frame_from, int32 subsampled_frame_to, Matrix<BaseFloat> *loglikes);
+  void LogLikelihoods(int32 subsampled_frame, int32 num_frames, Matrix<BaseFloat> *loglikes);
 
 
  protected:

--- a/src/nnet3/decodable-online-looped.h
+++ b/src/nnet3/decodable-online-looped.h
@@ -80,6 +80,8 @@ class DecodableNnetLoopedOnlineBase: public DecodableInterface {
   int32 FrameSubsamplingFactor() const {
     return info_.opts.frame_subsampling_factor;
   }
+  // Supply access to the loglikelihoods by row, for efficiency with pykaldi
+  SubVector<BaseFloat> LogLikelihoods(int32 subsampled_frame);
 
 
  protected:


### PR DESCRIPTION
This is my attempt to address https://github.com/pykaldi/pykaldi/issues/113, I hope this PR ends up with pykaldi and not kaldi-asr...

The idea is to provide row access to the posteriors/log-likelihoods of the nnet, as they are all computed together anyway.  

I've chose the base class, and using a non-virtual method, because with row-access there is no longer the `index - 1` difference between AmNnets and plain Nnets.  

This PR should be accompanied by a PR in pykaldi providing the CLIF wrapper. 