### PR TITLE
Add option `USE_LOCKING=1` to prevent thread-related bug in OpenBLAS

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -149,10 +149,10 @@ fortran_opt = $(shell gcc -v 2>&1 | perl -e '$$x = join(" ", <STDIN>); if($$x =~
 openblas_compiled:
 	echo "Note: see tools/Makefile for options regarding OpenBLAS compilation"
 	-git clone https://github.com/xianyi/OpenBLAS.git
-	-cd OpenBLAS; git pull
+	-cd OpenBLAS; git reset --hard HEAD; git pull
 	cd OpenBLAS; sed 's:# FCOMMON_OPT = -frecursive:FCOMMON_OPT = -frecursive:' < Makefile.rule >tmp && mv tmp Makefile.rule
 	# $(MAKE) PREFIX=`pwd`/OpenBLAS/install FC=gfortran $(fortran_opt) DEBUG=1 USE_THREAD=1 NUM_THREADS=64 -C OpenBLAS all install
-	$(MAKE) PREFIX=`pwd`/OpenBLAS/install FC=gfortran $(fortran_opt) DEBUG=1 USE_THREAD=0 -C OpenBLAS all install
+	$(MAKE) PREFIX=`pwd`/OpenBLAS/install FC=gfortran $(fortran_opt) DEBUG=1 USE_THREAD=0 USE_LOCKING=1 -C OpenBLAS all install
 
 
 .PHONY: cub


### PR DESCRIPTION
This PR fixes a somewhat strange interaction bug between Kaldi and OpenBLAS.  The bug was first reported [on the Kaldi mailing list](https://groups.google.com/d/msg/kaldi-help/BxvNZuxTgz0/iAoOGMqqBwAJ), and I happened to stumble across it while using pykaldi.  In [tracking the bug ](https://github.com/xianyi/OpenBLAS/issues/2155) we found a solution. 

Pykaldi uses a more recent OpenBLAS than plain Kaldi, it seems, so there actually is a 3-week old fix in OpenBLAS that can be used by pykaldi.  However, it needs an extra compile option `USE_LOCKING=1`, which this PR provides. 

Further, I added a `git reset --hard HEAD` in the Makefile, to make sure that a `make openblas` in tools/kaldi/tools actually gets the latest---the adaptation of `Makefile.rule` prevents further pulls, normally (this caused me to believe I had a recent OpenBLAS, where I didn't).  

